### PR TITLE
Fix 0.17.25 duplicate outputs (#5)

### DIFF
--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "vtk-deep-core-mining",
-  "version": "1.17.1",
+  "version": "1.17.2",
   "title": "VortiK's Deep core mining",
   "author": "VortiK",
   "homepage": "",

--- a/prototypes/deepcore-mining-items.lua
+++ b/prototypes/deepcore-mining-items.lua
@@ -248,10 +248,7 @@ local function chunk_refining_recipe_maker(
         icon_size = 32,
         results = 
         {
-            {type="item", name=refining_result, amount=result_amount/4}, 
-            {type="item", name=refining_result, amount=result_amount/4}, 
-            {type="item", name=refining_result, amount=result_amount/4}, 
-            {type="item", name=refining_result, amount=result_amount/4}, 
+            {type="item", name=refining_result, amount=result_amount},
         },
         crafting_machine_tint =
         {


### PR DESCRIPTION
Proposed fix for #5 that drops the division and replaces the recipe outputs with just one line. The recipes will look like the attached example screenshot after applying this patch.

<img width="391" alt="Screenshot 2019-04-05 18 21 54" src="https://user-images.githubusercontent.com/1398302/55643008-573ee880-57d2-11e9-8a10-b906b769da93.png">
