### PR TITLE
Mimic original ore

### DIFF
--- a/migrations/3.0.0.json
+++ b/migrations/3.0.0.json
@@ -1,0 +1,26 @@
+{
+  "item":
+  [
+    ["vtk-deepcore-mining-raw-rare-metals-chunk", "vtk-deepcore-mining-rare-metals-chunk"],
+    ["vtk-deepcore-mining-SiSi-quartz-chunk", "vtk-deepcore-mining-SiSi-quartz-ore-chunk"],
+    ["vtk-deepcore-mining-raw-borax-chunk", "vtk-deepcore-mining-borax-chunk"],
+    ["vtk-deepcore-mining-niobium-ore-chunk", "vtk-deepcore-mining-niobium-chunk"]
+  ],
+  "resource":
+  [
+    ["raw-rare-metals-patch", "rare-metals-patch"],
+    ["SiSi-quartz-patch", "SiSi-quartz-ore-patch"],
+    ["raw-borax-patch", "borax-patch"],
+    ["niobium-ore-patch", "niobium-patch"],
+
+    ["raw-rare-metals-patch-chunk", "rare-metals-patch-chunk"],
+    ["SiSi-quartz-patch-chunk", "SiSi-quartz-ore-patch-chunk"],
+    ["raw-borax-patch-chunk", "borax-patch-chunk"],
+    ["niobium-ore-patch-chunk", "niobium-patch-chunk"],
+
+    ["raw-rare-metals-patch-ore", "rare-metals-patch-ore"],
+    ["SiSi-quartz-patch-ore", "SiSi-quartz-ore-patch-ore"],
+    ["raw-borax-patch-ore", "borax-patch-ore"],
+    ["niobium-ore-patch-ore", "niobium-patch-ore"]
+  ]
+}

--- a/prototypes/deepcore-mining-refining.lua
+++ b/prototypes/deepcore-mining-refining.lua
@@ -76,7 +76,8 @@ for ore, oredata in pairs(vtk_deepcoremining_supported_ores) do
       oreprobability = 0.01
     end
     table.insert(data.raw['recipe']['vtk-deepcore-mining-ore-chunk-refining']['results'], {name = "vtk-deepcore-mining-"..ore.."-chunk", probability = 1, amount = 100 * oreprobability})
-    if oredata.result ~= "uranium-ore" then
+    if oredata.results and oredata.results[1] and
+        not (oredata.results[1].name == "uranium-ore" or oredata.results[1][1] == "uranium-ore") then
      table.insert(data.raw['recipe']['vtk-deepcore-mining-ore-chunk-refining-no-uranium']['results'], {name = "vtk-deepcore-mining-"..ore.."-chunk", probability = 1, amount = 100 * oreprobability})
     end
 
@@ -129,7 +130,7 @@ local function chunk_refining_recipe_maker(
   ore_icon, 
   ore_refining_result_icon, 
   ore_refining_result_icon_size,
-  refining_result, 
+  refining_results,
   result_amount, 
   refining_liquid,
   refining_liquid_amount,
@@ -139,6 +140,23 @@ local function chunk_refining_recipe_maker(
   machinetint,
   ore_order
 )
+  -- amplify each result by ``result_amount``
+  local mod_refining_results = util.table.deepcopy(refining_results)
+  for _,v in pairs(mod_refining_results) do
+    if v[2] then
+      v[2] = v[2] * result_amount
+    end
+    if v.amount then
+      v.amount = v.amount * result_amount
+    end
+    if v.amount_min then
+      v.amount_min = v.amount_min * result_amount
+    end
+    if v.amount_max then
+      v.amount_max = v.amount_max * result_amount
+    end
+  end
+
   local recipe =
   {
     type = "recipe",
@@ -171,10 +189,7 @@ local function chunk_refining_recipe_maker(
       }
     },
     icon_size = 64,
-    results = 
-    {
-      {type="item", name=refining_result, amount=result_amount},
-    },
+    results = mod_refining_results,
     crafting_machine_tint =
     {
       -- primary = {r = 0.000, g = 0.680, b = 0.894, a = 0.000}, -- #00ade45b -- to change?
@@ -224,7 +239,7 @@ for ore, oredata in pairs(vtk_deepcoremining_supported_ores) do
     oredata.img,                  -- ore refining icon "-chunk-refining.png"
     oreresulticon,                -- ore refining result icon
     oreresulticonsize,
-    oredata.result,               -- result
+    oredata.results,              -- results
     oredata.refineamount,         -- result amount
     sulfuricacidname,             -- refining liquid
     oredata.refineliquid,         -- refining liquid amount

--- a/prototypes/deepcore-mining-refining.lua
+++ b/prototypes/deepcore-mining-refining.lua
@@ -75,9 +75,9 @@ for ore, oredata in pairs(vtk_deepcoremining_supported_ores) do
     if oreprobability < 0.01 then
       oreprobability = 0.01
     end
-    table.insert(data.raw['recipe']['vtk-deepcore-mining-ore-chunk-refining']['results'], {name = "vtk-deepcore-mining-"..oredata.result.."-chunk", probability = 1, amount = 100 * oreprobability})
+    table.insert(data.raw['recipe']['vtk-deepcore-mining-ore-chunk-refining']['results'], {name = "vtk-deepcore-mining-"..ore.."-chunk", probability = 1, amount = 100 * oreprobability})
     if oredata.result ~= "uranium-ore" then
-     table.insert(data.raw['recipe']['vtk-deepcore-mining-ore-chunk-refining-no-uranium']['results'], {name = "vtk-deepcore-mining-"..oredata.result.."-chunk", probability = 1, amount = 100 * oreprobability})
+     table.insert(data.raw['recipe']['vtk-deepcore-mining-ore-chunk-refining-no-uranium']['results'], {name = "vtk-deepcore-mining-"..ore.."-chunk", probability = 1, amount = 100 * oreprobability})
     end
 
     -- on the fly focus deep core chunk refining recipes creation
@@ -87,7 +87,7 @@ for ore, oredata in pairs(vtk_deepcoremining_supported_ores) do
     -- ore_chunk_focus_recipe.ingredients = {{"vtk-deepcore-mining-ore-chunk", 200}, {"vtk-deepcore-mining-drone", 1}}
     ore_chunk_focus_recipe.energy_required = 4
     ore_chunk_focus_recipe.ingredients = {{"vtk-deepcore-mining-ore-chunk", 100}, {type="fluid", name=sulfuricacidname, amount=20}}
-    ore_chunk_focus_recipe.results = {{name = "vtk-deepcore-mining-"..oredata.result.."-chunk", amount = 150 * oreprobability}}
+    ore_chunk_focus_recipe.results = {{name = "vtk-deepcore-mining-"..ore.."-chunk", amount = 150 * oreprobability}}
 
     -- tint "generic" ores (like bobs)
     local oretint = nil
@@ -151,7 +151,7 @@ local function chunk_refining_recipe_maker(
     allow_decomposition = false,
     ingredients = 
     {
-      {"vtk-deepcore-mining-"..refining_result.."-chunk", 10},
+      {"vtk-deepcore-mining-"..ore_name.."-chunk", 10},
       {type="fluid", name=refining_liquid, amount=refining_liquid_amount},
       refining_liquid2 and {type="fluid", name=refining_liquid2, amount=refining_liquid2_amount},
     },

--- a/prototypes/deepcore-mining-resources.lua
+++ b/prototypes/deepcore-mining-resources.lua
@@ -308,7 +308,7 @@ local function resource_patch_maker(
       {
         {
           type = "item",
-          name = "vtk-deepcore-mining-"..ore_result.."-chunk", -- ore chunks
+          name = "vtk-deepcore-mining-"..ore_name.."-chunk", -- ore chunks
           amount_min = 2,
           amount_max = 4,
           probability = 1
@@ -418,7 +418,7 @@ for ore, oredata in pairs(vtk_deepcoremining_supported_ores) do
   end
   local ore_patch = resource_patch_maker(
     ore,                                                -- ore_name
-    oredata.result.."-patch",                           -- ore_patch_name
+    ore.."-patch",                                      -- ore_patch_name
     oredata.result,                                     -- patch mining ore result
     oredata.patchimg,                                   -- ore image name (icon, entity, hrentity)
     oredata.frame,                                      -- frame
@@ -468,7 +468,7 @@ for ore, oredata in pairs(vtk_deepcoremining_supported_ores) do
   local ore_chunk = 
   {
     type = "item",
-    name = "vtk-deepcore-mining-"..oredata.result.."-chunk",
+    name = "vtk-deepcore-mining-"..ore.."-chunk",
     icons = {
         {
             icon = "__vtk-deep-core-mining__/graphics/icons/ore-chunk-icon.png",

--- a/prototypes/deepcore-mining-supported-ore.lua
+++ b/prototypes/deepcore-mining-supported-ore.lua
@@ -6,8 +6,9 @@ if not vtk_deepcoremining_blacklist_ores then vtk_deepcoremining_blacklist_ores 
 -- Test blacklist
 -- vtk_deepcoremining_blacklist_ores["iron-ore"] = 1
 
-local vtk_custom_ores = {
+local vtk_custom_ores = {}
 
+{
   -- Factorio \o/
   ["iron-ore"] = {
     ["results"] = { { type="item", name="iron-ore", amount=1 } }, 

--- a/prototypes/deepcore-mining-supported-ore.lua
+++ b/prototypes/deepcore-mining-supported-ore.lua
@@ -696,9 +696,9 @@ if mods["bztitanium"] then
   }
 end
 
-{
-  -- Brevvens's Lead
-  ["lead-ore"] = {
+-- Brevvens's Lead
+if mods["bzlead"] then
+  vtk_custom_ores["lead-ore"] = {
     ["results"] = { { type="item", name="lead-ore", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore",
@@ -709,8 +709,10 @@ end
     ["probability"] = 0.30,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  
+  }
+end
+
+{
   -- Brevvens's Tungsten
   ["tungsten-ore"] = {
     ["results"] = { { type="item", name="tungsten-ore", amount=1 } },

--- a/prototypes/deepcore-mining-supported-ore.lua
+++ b/prototypes/deepcore-mining-supported-ore.lua
@@ -74,9 +74,9 @@ if mods["base"] then
   }
 end
 
-{
-  -- Simple Silicon
-  ["SiSi-quartz-ore"] = {
+-- Simple Silicon
+if mods["SimpleSilicon"] then
+  vtk_custom_ores["SiSi-quartz-ore"] = {
     ["results"] = { { type="item", name="SiSi-quartz", amount=1 } }, 
     ["mining-liquid"] = "water", 
     ["mining-liquid-amount"] = 100, 
@@ -89,8 +89,10 @@ end
     ["probability"] = 0.20,
     ["tint"] = true,
     ["patchtint"] = true
-  },
+  }
+end
 
+{
   -- Angel's ores
   ["angels-ore1"] = {
     ["results"] = { { type="item", name="angels-ore1", amount=1 } }, 

--- a/prototypes/deepcore-mining-supported-ore.lua
+++ b/prototypes/deepcore-mining-supported-ore.lua
@@ -678,9 +678,9 @@ if mods["pycoalprocessing"] then
   }
 end
 
-{
-  -- Brevvens's Titanium
-  ["titanium-ore"] = {
+-- Brevvens's Titanium
+if mods["bztitanium"] then
+  vtk_custom_ores["titanium-ore"] = {
     ["results"] = { { type="item", name="titanium-ore", amount=1 } },
     ["mining-liquid"] = "lubricant", 
     ["mining-liquid-amount"] = 30, 
@@ -693,8 +693,10 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
+  }
+end
 
+{
   -- Brevvens's Lead
   ["lead-ore"] = {
     ["results"] = { { type="item", name="lead-ore", amount=1 } },

--- a/prototypes/deepcore-mining-supported-ore.lua
+++ b/prototypes/deepcore-mining-supported-ore.lua
@@ -470,9 +470,9 @@ if mods["Krastorio2"] then
   }
 end
 
-{
-  -- Omnimatter
-  ["omnite"] = {
+-- Omnimatter
+if mods["omnimatter"] then
+  vtk_custom_ores["omnite"] = {
     ["results"] = { { type="item", name="omnite", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore", 
@@ -483,8 +483,10 @@ end
     ["probability"] = 1, -- obviously, there's only omnite :D
     ["tint"] = true,
     ["patchtint"] = true
-  },
+  }
+end
 
+{
   -- Leighzer's Morphite support
   ["morphite-ore"] = {
     ["results"] = { { type="item", name="morphite-ore", amount=1 } },

--- a/prototypes/deepcore-mining-supported-ore.lua
+++ b/prototypes/deepcore-mining-supported-ore.lua
@@ -486,9 +486,9 @@ if mods["omnimatter"] then
   }
 end
 
-{
-  -- Leighzer's Morphite support
-  ["morphite-ore"] = {
+-- Leighzer's Morphite support
+if mods["leighzermorphite"] then
+  vtk_custom_ores["morphite-ore"] = {
     ["results"] = { { type="item", name="morphite-ore", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore", 
@@ -499,8 +499,10 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
+  }
+end
 
+{
   -- Pyanodon's Raw Ores support
   ["ore-tin"] = {
     ["results"] = { { type="item", name="ore-tin", amount=1 } },

--- a/prototypes/deepcore-mining-supported-ore.lua
+++ b/prototypes/deepcore-mining-supported-ore.lua
@@ -92,9 +92,9 @@ if mods["SimpleSilicon"] then
   }
 end
 
-{
-  -- Angel's ores
-  ["angels-ore1"] = {
+-- Angel's ores
+if mods["angelsrefining"] then
+  vtk_custom_ores["angels-ore1"] = {
     ["results"] = { { type="item", name="angels-ore1", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -105,8 +105,8 @@ end
     ["probability"] = 0.50,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["angels-ore2"] = {
+  }
+  vtk_custom_ores["angels-ore2"] = {
     ["results"] = { { type="item", name="angels-ore2", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -117,8 +117,8 @@ end
     ["probability"] = 0.50,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["angels-ore3"] = {
+  }
+  vtk_custom_ores["angels-ore3"] = {
     ["results"] = { { type="item", name="angels-ore3", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -129,8 +129,8 @@ end
     ["probability"] = 0.30,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["angels-ore4"] = {
+  }
+  vtk_custom_ores["angels-ore4"] = {
     ["results"] = { { type="item", name="angels-ore4", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -141,8 +141,8 @@ end
     ["probability"] = 0.30,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["angels-ore5"] = {
+  }
+  vtk_custom_ores["angels-ore5"] = {
     ["results"] = { { type="item", name="angels-ore5", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -153,8 +153,8 @@ end
     ["probability"] = 0.30,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["angels-ore6"] = {
+  }
+  vtk_custom_ores["angels-ore6"] = {
     ["results"] = { { type="item", name="angels-ore6", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -165,8 +165,10 @@ end
     ["probability"] = 0.30,
     ["tint"] = true,
     ["patchtint"] = true
-  },
+  }
+end
 
+{
   -- Mad Clown's Extended Angel's Bob's Minerals ores
   ["clowns-ore1"] = {
     ["results"] = { { type="item", name="clowns-ore1", amount=1 } }, 

--- a/prototypes/deepcore-mining-supported-ore.lua
+++ b/prototypes/deepcore-mining-supported-ore.lua
@@ -729,9 +729,9 @@ if mods["bztungsten"] then
   }
 end
 
-{
-  -- Brevvens's Zirconium
-  ["zircon"] = {
+-- Brevvens's Zirconium
+if mods["bzzirconium"] then
+  vtk_custom_ores["zircon"] = {
     ["results"] = { { type="item", name="zircon", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore",
@@ -742,8 +742,10 @@ end
     ["probability"] = 0.30,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  
+  }
+end
+
+{
   -- Space Exploration's ore support
   ["se-beryllium-ore"] = {
     ["results"] = { { type="item", name="se-beryllium-ore", amount=1 } },

--- a/prototypes/deepcore-mining-supported-ore.lua
+++ b/prototypes/deepcore-mining-supported-ore.lua
@@ -861,9 +861,9 @@ if mods["space-exploration"] then
   }
 end
 
-{
-  --Industrial Revolution 2
-  ["tin-ore"] = {
+--Industrial Revolution 2
+if mods["IndustrialRevolution"] then
+  vtk_custom_ores["tin-ore"] = {
     ["results"] = { { type="item", name="tin-ore", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore",
@@ -874,8 +874,8 @@ end
     ["probability"] = 0.30,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["gold-ore"] = {
+  }
+  vtk_custom_ores["gold-ore"] = {
     ["results"] = { { type="item", name="gold-ore", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore",
@@ -886,8 +886,8 @@ end
     ["probability"] = 0.15,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-}
+  }
+end
 
 
 -- Process all existing resources to create deepcore mining reference for them to create associated patches, items, refining and technology

--- a/prototypes/deepcore-mining-supported-ore.lua
+++ b/prototypes/deepcore-mining-supported-ore.lua
@@ -919,10 +919,14 @@ for _, resource in pairs(data.raw.resource) do
           ["probability"] = 0.10,
           ["tint"] = true,
           ["patchtint"] = true,
-          --["mining-liquid"] = resource.minable.required_fluid, 
-          --["mining-liquid-amount"] = resource.minable.fluid_amount*10, 
         }
       }
+      if resource.minable.required_fluid then
+        resources_to_support[resource.name]["mining-liquid"] = resource.minable.required_fluid
+      end
+      if resource.minable.fluid_amount then
+        resources_to_support[resource.name]["mining-liquid-amount"] = resource.minable.fluid_amount*10
+      end
       vtk_deepcoremining_supported_ores[resource.name] = resources_to_support[resource.name]
     end
   end

--- a/prototypes/deepcore-mining-supported-ore.lua
+++ b/prototypes/deepcore-mining-supported-ore.lua
@@ -745,9 +745,9 @@ if mods["bzzirconium"] then
   }
 end
 
-{
-  -- Space Exploration's ore support
-  ["se-beryllium-ore"] = {
+-- Space Exploration's ore support
+if mods["space-exploration"] then
+  vtk_custom_ores["se-beryllium-ore"] = {
     ["results"] = { { type="item", name="se-beryllium-ore", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore",
@@ -758,8 +758,8 @@ end
     ["probability"] = 0,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["se-cryonite"] = {
+  }
+  vtk_custom_ores["se-cryonite"] = {
     ["results"] = { { type="item", name="se-cryonite", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore",
@@ -770,8 +770,8 @@ end
     ["probability"] = 0,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["se-holmium-ore"] = {
+  }
+  vtk_custom_ores["se-holmium-ore"] = {
     ["results"] = { { type="item", name="se-holmium-ore", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore",
@@ -782,8 +782,8 @@ end
     ["probability"] = 0,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["se-iridium-ore"] = {
+  }
+  vtk_custom_ores["se-iridium-ore"] = {
     ["results"] = { { type="item", name="se-iridium-ore", amount=1 } },
     ["mining-liquid"] = "sulfuric-acid", 
     ["mining-liquid-amount"] = 50, 
@@ -796,8 +796,8 @@ end
     ["probability"] = 0,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["se-naquium-ore"] = {
+  }
+  vtk_custom_ores["se-naquium-ore"] = {
     ["results"] = { { type="item", name="se-naquium-ore", amount=1 } },
     ["mining-liquid"] = "sulfuric-acid", 
     ["mining-liquid-amount"] = 200, 
@@ -810,8 +810,8 @@ end
     ["probability"] = 0,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["se-vulcanite"] = {
+  }
+  vtk_custom_ores["se-vulcanite"] = {
     ["results"] = { { type="item", name="se-vulcanite", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore",
@@ -822,8 +822,8 @@ end
     ["probability"] = 0,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["se-vitamelange"] = {
+  }
+  vtk_custom_ores["se-vitamelange"] = {
     ["results"] = { { type="item", name="se-vitamelange", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore",
@@ -834,8 +834,8 @@ end
     ["probability"] = 0,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["se-water-ice"] = {
+  }
+  vtk_custom_ores["se-water-ice"] = {
     ["results"] = { { type="item", name="se-water-ice", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore",
@@ -846,8 +846,8 @@ end
     ["probability"] = 0,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["se-methane-ice"] = {
+  }
+  vtk_custom_ores["se-methane-ice"] = {
     ["results"] = { { type="item", name="se-methane-ice", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore",
@@ -858,8 +858,10 @@ end
     ["probability"] = 0,
     ["tint"] = true,
     ["patchtint"] = true
-  },
+  }
+end
 
+{
   --Industrial Revolution 2
   ["tin-ore"] = {
     ["results"] = { { type="item", name="tin-ore", amount=1 } },

--- a/prototypes/deepcore-mining-supported-ore.lua
+++ b/prototypes/deepcore-mining-supported-ore.lua
@@ -8,9 +8,9 @@ if not vtk_deepcoremining_blacklist_ores then vtk_deepcoremining_blacklist_ores 
 
 local vtk_custom_ores = {}
 
-{
-  -- Factorio \o/
-  ["iron-ore"] = {
+-- Factorio \o/
+if mods["base"] then
+  vtk_custom_ores["iron-ore"] = {
     ["results"] = { { type="item", name="iron-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "iron-ore", 
@@ -21,8 +21,8 @@ local vtk_custom_ores = {}
     ["probability"] = 0.50,
     ["tint"] = true,
     ["patchtint"] = false
-  },
-  ["copper-ore"] = {
+  }
+  vtk_custom_ores["copper-ore"] = {
     ["results"] = { { type="item", name="copper-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "copper-ore", 
@@ -33,8 +33,8 @@ local vtk_custom_ores = {}
     ["probability"] = 0.40,
     ["tint"] = true,
     ["patchtint"] = false
-  },
-  ["stone"] = {
+  }
+  vtk_custom_ores["stone"] = {
     ["results"] = { { type="item", name="stone", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "stone", 
@@ -45,8 +45,8 @@ local vtk_custom_ores = {}
     ["probability"] = 0.07,
     ["tint"] = true,
     ["patchtint"] = false
-  },
-  ["coal"] = {
+  }
+  vtk_custom_ores["coal"] = {
     ["results"] = { { type="item", name="coal", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "coal", 
@@ -57,8 +57,8 @@ local vtk_custom_ores = {}
     ["probability"] = 0.06,
     ["tint"] = true,
     ["patchtint"] = false
-  },
-  ["uranium-ore"] = {
+  }
+  vtk_custom_ores["uranium-ore"] = {
     ["results"] = { { type="item", name="uranium-ore", amount=1 } }, 
     ["mining-liquid"] = "sulfuric-acid", 
     ["mining-liquid-amount"] = 100, 
@@ -71,8 +71,10 @@ local vtk_custom_ores = {}
     ["probability"] = 0.01,
     ["tint"] = true,
     ["patchtint"] = false
-  },
+  }
+end
 
+{
   -- Simple Silicon
   ["SiSi-quartz-ore"] = {
     ["results"] = { { type="item", name="SiSi-quartz", amount=1 } }, 

--- a/prototypes/deepcore-mining-supported-ore.lua
+++ b/prototypes/deepcore-mining-supported-ore.lua
@@ -502,9 +502,9 @@ if mods["leighzermorphite"] then
   }
 end
 
-{
-  -- Pyanodon's Raw Ores support
-  ["ore-tin"] = {
+-- Pyanodon's Raw Ores support
+if mods["pyrawores"] then
+  vtk_custom_ores["ore-tin"] = {
     ["results"] = { { type="item", name="ore-tin", amount=1 } },
     ["mining-liquid"] = "steam",
     ["mining-liquid-amount"] = 100,
@@ -519,8 +519,8 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["ore-quartz"] = {
+  }
+  vtk_custom_ores["ore-quartz"] = {
     ["results"] = { { type="item", name="ore-quartz", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore", 
@@ -531,8 +531,8 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["ore-aluminium"] = {
+  }
+  vtk_custom_ores["ore-aluminium"] = {
     ["results"] = { { type="item", name="ore-aluminium", amount=1 } },
     ["mining-liquid"] = "coal-gas",
     ["mining-liquid-amount"] = 100,
@@ -547,8 +547,8 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["ore-chromium"] = {
+  }
+  vtk_custom_ores["ore-chromium"] = {
     ["results"] = { { type="item", name="ore-chromium", amount=1 } },
     ["mining-liquid"] = "syngas",
     ["mining-liquid-amount"] = 40,
@@ -563,8 +563,8 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["ore-lead"] = {
+  }
+  vtk_custom_ores["ore-lead"] = {
     ["results"] = { { type="item", name="ore-lead", amount=1 } },
     ["mining-liquid"] = "acetylene",
     ["mining-liquid-amount"] = 100,
@@ -579,8 +579,8 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["ore-nickel"] = {
+  }
+  vtk_custom_ores["ore-nickel"] = {
     ["results"] = { { type="item", name="ore-nickel", amount=1 } },
     ["mining-liquid"] = "syngas",
     ["mining-liquid-amount"] = 40,
@@ -595,8 +595,8 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["raw-coal"] = {
+  }
+  vtk_custom_ores["raw-coal"] = {
     ["results"] = { { type="item", name="raw-coal", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore", 
@@ -607,8 +607,8 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["ore-titanium"] = {
+  }
+  vtk_custom_ores["ore-titanium"] = {
     ["results"] = { { type="item", name="ore-titanium", amount=1 } },
     ["mining-liquid"] = "acetylene",
     ["mining-liquid-amount"] = 40,
@@ -623,8 +623,8 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["ore-zinc"] = {
+  }
+  vtk_custom_ores["ore-zinc"] = {
     ["results"] = { { type="item", name="ore-zinc", amount=1 } },
     ["mining-liquid"] = "syngas",
     ["mining-liquid-amount"] = 40,
@@ -639,8 +639,10 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
+  }
+end
 
+{
   -- Pyanodons Coal Processing support
   ["borax"] = {
     ["results"] = { { type="item", name="raw-borax", amount=1 } },

--- a/prototypes/deepcore-mining-supported-ore.lua
+++ b/prototypes/deepcore-mining-supported-ore.lua
@@ -280,9 +280,9 @@ if mods["Clowns-Extended-Minerals"] then
   }
 end
 
-{
-  -- Bob's ores
-  ["tin-ore"] = {
+-- Bob's ores
+if mods["bobores"] then
+  vtk_custom_ores["tin-ore"] = {
     ["results"] = { { type="item", name="tin-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -293,8 +293,8 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["lead-ore"] = {
+  }
+  vtk_custom_ores["lead-ore"] = {
     ["results"] = { { type="item", name="lead-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -305,8 +305,8 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["quartz"] =  {
+  }
+  vtk_custom_ores["quartz"] =  {
     ["results"] = { { type="item", name="quartz", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -317,8 +317,8 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["silver-ore"] = {
+  }
+  vtk_custom_ores["silver-ore"] = {
     ["results"] = { { type="item", name="silver-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -329,8 +329,8 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["zinc-ore"] = {
+  }
+  vtk_custom_ores["zinc-ore"] = {
     ["results"] = { { type="item", name="zinc-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -341,8 +341,8 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["gold-ore"] = {
+  }
+  vtk_custom_ores["gold-ore"] = {
     ["results"] = { { type="item", name="gold-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -353,8 +353,8 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["bauxite-ore"] = {
+  }
+  vtk_custom_ores["bauxite-ore"] = {
     ["results"] = { { type="item", name="bauxite-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -365,8 +365,8 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["rutile-ore"] = {
+  }
+  vtk_custom_ores["rutile-ore"] = {
     ["results"] = { { type="item", name="rutile-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -377,8 +377,8 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["tungsten-ore"] = {
+  }
+  vtk_custom_ores["tungsten-ore"] = {
     ["results"] = { { type="item", name="tungsten-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -389,8 +389,8 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["thorium-ore"] = {
+  }
+  vtk_custom_ores["thorium-ore"] = {
     ["results"] = { { type="item", name="thorium-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -401,8 +401,8 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["nickel-ore"] = {
+  }
+  vtk_custom_ores["nickel-ore"] = {
     ["results"] = { { type="item", name="nickel-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -413,8 +413,8 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["cobalt-ore"] = {
+  }
+  vtk_custom_ores["cobalt-ore"] = {
     ["results"] = { { type="item", name="cobalt-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -425,8 +425,8 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["sulfur"] = {
+  }
+  vtk_custom_ores["sulfur"] = {
     ["results"] = { { type="item", name="sulfur", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -437,8 +437,8 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["gem-ore"] = {
+  }
+  vtk_custom_ores["gem-ore"] = {
     ["results"] = { { type="item", name="gem-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -449,8 +449,10 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
+  }
+end
 
+{
   -- Krastorio 2 Rare Metals
   ["rare-metals"] = {
     ["results"] = { { type="item", name="raw-rare-metals", amount=1 } }, 

--- a/prototypes/deepcore-mining-supported-ore.lua
+++ b/prototypes/deepcore-mining-supported-ore.lua
@@ -168,9 +168,9 @@ if mods["angelsrefining"] then
   }
 end
 
-{
-  -- Mad Clown's Extended Angel's Bob's Minerals ores
-  ["clowns-ore1"] = {
+-- Mad Clown's Extended Angel's Bob's Minerals ores
+if mods["Clowns-Extended-Minerals"] then
+  vtk_custom_ores["clowns-ore1"] = {
     ["results"] = { { type="item", name="clowns-ore1", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -181,8 +181,8 @@ end
     ["probability"] = 0.07,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["clowns-ore2"] = {
+  }
+  vtk_custom_ores["clowns-ore2"] = {
     ["results"] = { { type="item", name="clowns-ore2", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -193,8 +193,8 @@ end
     ["probability"] = 0.22,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["clowns-ore3"] = {
+  }
+  vtk_custom_ores["clowns-ore3"] = {
     ["results"] = { { type="item", name="clowns-ore3", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -205,8 +205,8 @@ end
     ["probability"] = 0.22,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["clowns-ore4"] = {
+  }
+  vtk_custom_ores["clowns-ore4"] = {
     ["results"] = { { type="item", name="clowns-ore4", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -217,8 +217,8 @@ end
     ["probability"] = 0.22,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["clowns-ore5"] = {
+  }
+  vtk_custom_ores["clowns-ore5"] = {
     ["results"] = { { type="item", name="clowns-ore5", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -229,8 +229,8 @@ end
     ["probability"] = 0.22,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["clowns-ore6"] = {
+  }
+  vtk_custom_ores["clowns-ore6"] = {
     ["results"] = { { type="item", name="clowns-ore6", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -241,8 +241,8 @@ end
     ["probability"] = 0.15,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["clowns-ore7"] = {
+  }
+  vtk_custom_ores["clowns-ore7"] = {
     ["results"] = { { type="item", name="clowns-ore7", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -253,8 +253,8 @@ end
     ["probability"] = 0.15,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["clowns-ore8"] = {
+  }
+  vtk_custom_ores["clowns-ore8"] = {
     ["results"] = { { type="item", name="clowns-ore8", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -265,8 +265,8 @@ end
     ["probability"] = 0.07,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["clowns-ore9"] = {
+  }
+  vtk_custom_ores["clowns-ore9"] = {
     ["results"] = { { type="item", name="clowns-ore9", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
@@ -277,8 +277,10 @@ end
     ["probability"] = 0.07,
     ["tint"] = true,
     ["patchtint"] = true
-  },
+  }
+end
 
+{
   -- Bob's ores
   ["tin-ore"] = {
     ["results"] = { { type="item", name="tin-ore", amount=1 } }, 

--- a/prototypes/deepcore-mining-supported-ore.lua
+++ b/prototypes/deepcore-mining-supported-ore.lua
@@ -712,9 +712,9 @@ if mods["bzlead"] then
   }
 end
 
-{
-  -- Brevvens's Tungsten
-  ["tungsten-ore"] = {
+-- Brevvens's Tungsten
+if mods["bztungsten"] then
+  vtk_custom_ores["tungsten-ore"] = {
     ["results"] = { { type="item", name="tungsten-ore", amount=1 } },
     ["mining-liquid"] = "water",
     ["mining-liquid-amount"] = 100,
@@ -726,8 +726,10 @@ end
     ["probability"] = 0.30,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  
+  }
+end
+
+{
   -- Brevvens's Zirconium
   ["zircon"] = {
     ["results"] = { { type="item", name="zircon", amount=1 } },

--- a/prototypes/deepcore-mining-supported-ore.lua
+++ b/prototypes/deepcore-mining-supported-ore.lua
@@ -452,9 +452,9 @@ if mods["bobores"] then
   }
 end
 
-{
-  -- Krastorio 2 Rare Metals
-  ["rare-metals"] = {
+-- Krastorio 2 Rare Metals
+if mods["Krastorio2"] then
+  vtk_custom_ores["rare-metals"] = {
     ["results"] = { { type="item", name="raw-rare-metals", amount=1 } }, 
     ["mining-liquid"] = "chlorine", 
     ["mining-liquid-amount"] = 25, 
@@ -467,8 +467,10 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
+  }
+end
 
+{
   -- Omnimatter
   ["omnite"] = {
     ["results"] = { { type="item", name="omnite", amount=1 } },

--- a/prototypes/deepcore-mining-supported-ore.lua
+++ b/prototypes/deepcore-mining-supported-ore.lua
@@ -642,9 +642,9 @@ if mods["pyrawores"] then
   }
 end
 
-{
-  -- Pyanodons Coal Processing support
-  ["borax"] = {
+-- Pyanodons Coal Processing support
+if mods["pycoalprocessing"] then
+  vtk_custom_ores["borax"] = {
     ["results"] = { { type="item", name="raw-borax", amount=1 } },
     ["mining-liquid"] = "syngas",
     ["mining-liquid-amount"] = 50,
@@ -659,8 +659,8 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  ["niobium"] = {
+  }
+  vtk_custom_ores["niobium"] = {
     ["results"] = { { type="item", name="niobium-ore", amount=1 } },
     ["mining-liquid"] = "refsyngas",
     ["mining-liquid-amount"] = 60,
@@ -675,8 +675,10 @@ end
     ["probability"] = 0.10,
     ["tint"] = true,
     ["patchtint"] = true
-  },
-  
+  }
+end
+
+{
   -- Brevvens's Titanium
   ["titanium-ore"] = {
     ["results"] = { { type="item", name="titanium-ore", amount=1 } },

--- a/prototypes/deepcore-mining-supported-ore.lua
+++ b/prototypes/deepcore-mining-supported-ore.lua
@@ -10,7 +10,7 @@ local vtk_custom_ores = {
 
   -- Factorio \o/
   ["iron-ore"] = {
-    ["result"] = "iron-ore", 
+    ["results"] = { { type="item", name="iron-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "iron-ore", 
     ["frame"] = 3, 
@@ -22,7 +22,7 @@ local vtk_custom_ores = {
     ["patchtint"] = false
   },
   ["copper-ore"] = {
-    ["result"] = "copper-ore", 
+    ["results"] = { { type="item", name="copper-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "copper-ore", 
     ["frame"] = 3,
@@ -34,7 +34,7 @@ local vtk_custom_ores = {
     ["patchtint"] = false
   },
   ["stone"] = {
-    ["result"] = "stone", 
+    ["results"] = { { type="item", name="stone", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "stone", 
     ["frame"] = 3,
@@ -46,7 +46,7 @@ local vtk_custom_ores = {
     ["patchtint"] = false
   },
   ["coal"] = {
-    ["result"] = "coal", 
+    ["results"] = { { type="item", name="coal", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "coal", 
     ["frame"] = 3,
@@ -58,7 +58,7 @@ local vtk_custom_ores = {
     ["patchtint"] = false
   },
   ["uranium-ore"] = {
-    ["result"] = "uranium-ore", 
+    ["results"] = { { type="item", name="uranium-ore", amount=1 } }, 
     ["mining-liquid"] = "sulfuric-acid", 
     ["mining-liquid-amount"] = 100, 
     ["img"] = "ore", 
@@ -74,7 +74,7 @@ local vtk_custom_ores = {
 
   -- Simple Silicon
   ["SiSi-quartz-ore"] = {
-    ["result"] = "SiSi-quartz", 
+    ["results"] = { { type="item", name="SiSi-quartz", amount=1 } }, 
     ["mining-liquid"] = "water", 
     ["mining-liquid-amount"] = 100, 
     ["img"] = "ore", 
@@ -90,7 +90,7 @@ local vtk_custom_ores = {
 
   -- Angel's ores
   ["angels-ore1"] = {
-    ["result"] = "angels-ore1", 
+    ["results"] = { { type="item", name="angels-ore1", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4, 
@@ -102,7 +102,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["angels-ore2"] = {
-    ["result"] = "angels-ore2", 
+    ["results"] = { { type="item", name="angels-ore2", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4, 
@@ -114,7 +114,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["angels-ore3"] = {
-    ["result"] = "angels-ore3", 
+    ["results"] = { { type="item", name="angels-ore3", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4, 
@@ -126,7 +126,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["angels-ore4"] = {
-    ["result"] = "angels-ore4", 
+    ["results"] = { { type="item", name="angels-ore4", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4, 
@@ -138,7 +138,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["angels-ore5"] = {
-    ["result"] = "angels-ore5", 
+    ["results"] = { { type="item", name="angels-ore5", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4, 
@@ -150,7 +150,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["angels-ore6"] = {
-    ["result"] = "angels-ore6", 
+    ["results"] = { { type="item", name="angels-ore6", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4, 
@@ -164,7 +164,7 @@ local vtk_custom_ores = {
 
   -- Mad Clown's Extended Angel's Bob's Minerals ores
   ["clowns-ore1"] = {
-    ["result"] = "clowns-ore1", 
+    ["results"] = { { type="item", name="clowns-ore1", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4,
@@ -176,7 +176,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["clowns-ore2"] = {
-    ["result"] = "clowns-ore2", 
+    ["results"] = { { type="item", name="clowns-ore2", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4,
@@ -188,7 +188,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["clowns-ore3"] = {
-    ["result"] = "clowns-ore3", 
+    ["results"] = { { type="item", name="clowns-ore3", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4,
@@ -200,7 +200,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["clowns-ore4"] = {
-    ["result"] = "clowns-ore4", 
+    ["results"] = { { type="item", name="clowns-ore4", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4,
@@ -212,7 +212,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["clowns-ore5"] = {
-    ["result"] = "clowns-ore5", 
+    ["results"] = { { type="item", name="clowns-ore5", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4,
@@ -224,7 +224,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["clowns-ore6"] = {
-    ["result"] = "clowns-ore6", 
+    ["results"] = { { type="item", name="clowns-ore6", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4,
@@ -236,7 +236,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["clowns-ore7"] = {
-    ["result"] = "clowns-ore7", 
+    ["results"] = { { type="item", name="clowns-ore7", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4,
@@ -248,7 +248,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["clowns-ore8"] = {
-    ["result"] = "clowns-ore8", 
+    ["results"] = { { type="item", name="clowns-ore8", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4,
@@ -260,7 +260,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["clowns-ore9"] = {
-    ["result"] = "clowns-ore9", 
+    ["results"] = { { type="item", name="clowns-ore9", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4,
@@ -274,7 +274,7 @@ local vtk_custom_ores = {
 
   -- Bob's ores
   ["tin-ore"] = {
-    ["result"] = "tin-ore", 
+    ["results"] = { { type="item", name="tin-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4, 
@@ -286,7 +286,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["lead-ore"] = {
-    ["result"] = "lead-ore", 
+    ["results"] = { { type="item", name="lead-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4, 
@@ -298,7 +298,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["quartz"] =  {
-    ["result"] = "quartz", 
+    ["results"] = { { type="item", name="quartz", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4, 
@@ -310,7 +310,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["silver-ore"] = {
-    ["result"] = "silver-ore", 
+    ["results"] = { { type="item", name="silver-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4, 
@@ -322,7 +322,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["zinc-ore"] = {
-    ["result"] = "zinc-ore", 
+    ["results"] = { { type="item", name="zinc-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4, 
@@ -334,7 +334,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["gold-ore"] = {
-    ["result"] = "gold-ore", 
+    ["results"] = { { type="item", name="gold-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4, 
@@ -346,7 +346,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["bauxite-ore"] = {
-    ["result"] = "bauxite-ore", 
+    ["results"] = { { type="item", name="bauxite-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4, 
@@ -358,7 +358,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["rutile-ore"] = {
-    ["result"] = "rutile-ore", 
+    ["results"] = { { type="item", name="rutile-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4, 
@@ -370,7 +370,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["tungsten-ore"] = {
-    ["result"] = "tungsten-ore", 
+    ["results"] = { { type="item", name="tungsten-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4, 
@@ -382,7 +382,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["thorium-ore"] = {
-    ["result"] = "thorium-ore", 
+    ["results"] = { { type="item", name="thorium-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4, 
@@ -394,7 +394,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["nickel-ore"] = {
-    ["result"] = "nickel-ore", 
+    ["results"] = { { type="item", name="nickel-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4, 
@@ -406,7 +406,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["cobalt-ore"] = {
-    ["result"] = "cobalt-ore", 
+    ["results"] = { { type="item", name="cobalt-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4, 
@@ -418,7 +418,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["sulfur"] = {
-    ["result"] = "sulfur", 
+    ["results"] = { { type="item", name="sulfur", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4, 
@@ -430,7 +430,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["gem-ore"] = {
-    ["result"] = "gem-ore", 
+    ["results"] = { { type="item", name="gem-ore", amount=1 } }, 
     ["img"] = "ore", 
     ["patchimg"] = "ore", 
     ["frame"] = 4, 
@@ -444,7 +444,7 @@ local vtk_custom_ores = {
 
   -- Krastorio 2 Rare Metals
   ["rare-metals"] = {
-    ["result"] = "raw-rare-metals", 
+    ["results"] = { { type="item", name="raw-rare-metals", amount=1 } }, 
     ["mining-liquid"] = "chlorine", 
     ["mining-liquid-amount"] = 25, 
     ["img"] = "ore", 
@@ -460,7 +460,7 @@ local vtk_custom_ores = {
 
   -- Omnimatter
   ["omnite"] = {
-    ["result"] = "omnite",
+    ["results"] = { { type="item", name="omnite", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore", 
     ["frame"] = 4,
@@ -474,7 +474,7 @@ local vtk_custom_ores = {
 
   -- Leighzer's Morphite support
   ["morphite-ore"] = {
-    ["result"] = "morphite-ore",
+    ["results"] = { { type="item", name="morphite-ore", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore", 
     ["frame"] = 4,
@@ -488,7 +488,7 @@ local vtk_custom_ores = {
 
   -- Pyanodon's Raw Ores support
   ["ore-tin"] = {
-    ["result"] = "ore-tin",
+    ["results"] = { { type="item", name="ore-tin", amount=1 } },
     ["mining-liquid"] = "steam",
     ["mining-liquid-amount"] = 100,
     ["img"] = "ore",
@@ -504,7 +504,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["ore-quartz"] = {
-    ["result"] = "ore-quartz",
+    ["results"] = { { type="item", name="ore-quartz", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore", 
     ["frame"] = 4,
@@ -516,7 +516,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["ore-aluminium"] = {
-    ["result"] = "ore-aluminium",
+    ["results"] = { { type="item", name="ore-aluminium", amount=1 } },
     ["mining-liquid"] = "coal-gas",
     ["mining-liquid-amount"] = 100,
     ["img"] = "ore",
@@ -532,7 +532,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["ore-chromium"] = {
-    ["result"] = "ore-chromium",
+    ["results"] = { { type="item", name="ore-chromium", amount=1 } },
     ["mining-liquid"] = "syngas",
     ["mining-liquid-amount"] = 40,
     ["img"] = "ore",
@@ -548,7 +548,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["ore-lead"] = {
-    ["result"] = "ore-lead",
+    ["results"] = { { type="item", name="ore-lead", amount=1 } },
     ["mining-liquid"] = "acetylene",
     ["mining-liquid-amount"] = 100,
     ["img"] = "ore",
@@ -564,7 +564,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["ore-nickel"] = {
-    ["result"] = "ore-nickel",
+    ["results"] = { { type="item", name="ore-nickel", amount=1 } },
     ["mining-liquid"] = "syngas",
     ["mining-liquid-amount"] = 40,
     ["img"] = "ore",
@@ -580,7 +580,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["raw-coal"] = {
-    ["result"] = "raw-coal",
+    ["results"] = { { type="item", name="raw-coal", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore", 
     ["frame"] = 4,
@@ -592,7 +592,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["ore-titanium"] = {
-    ["result"] = "ore-titanium",
+    ["results"] = { { type="item", name="ore-titanium", amount=1 } },
     ["mining-liquid"] = "acetylene",
     ["mining-liquid-amount"] = 40,
     ["img"] = "ore",
@@ -608,7 +608,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["ore-zinc"] = {
-    ["result"] = "ore-zinc",
+    ["results"] = { { type="item", name="ore-zinc", amount=1 } },
     ["mining-liquid"] = "syngas",
     ["mining-liquid-amount"] = 40,
     ["img"] = "ore",
@@ -626,7 +626,7 @@ local vtk_custom_ores = {
 
   -- Pyanodons Coal Processing support
   ["borax"] = {
-    ["result"] = "raw-borax",
+    ["results"] = { { type="item", name="raw-borax", amount=1 } },
     ["mining-liquid"] = "syngas",
     ["mining-liquid-amount"] = 50,
     ["img"] = "ore",
@@ -642,7 +642,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["niobium"] = {
-    ["result"] = "niobium-ore",
+    ["results"] = { { type="item", name="niobium-ore", amount=1 } },
     ["mining-liquid"] = "refsyngas",
     ["mining-liquid-amount"] = 60,
     ["img"] = "ore",
@@ -660,7 +660,7 @@ local vtk_custom_ores = {
   
   -- Brevvens's Titanium
   ["titanium-ore"] = {
-    ["result"] = "titanium-ore",
+    ["results"] = { { type="item", name="titanium-ore", amount=1 } },
     ["mining-liquid"] = "lubricant", 
     ["mining-liquid-amount"] = 30, 
     ["img"] = "ore",
@@ -676,7 +676,7 @@ local vtk_custom_ores = {
 
   -- Brevvens's Lead
   ["lead-ore"] = {
-    ["result"] = "lead-ore",
+    ["results"] = { { type="item", name="lead-ore", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore",
     ["frame"] = 4,
@@ -690,7 +690,7 @@ local vtk_custom_ores = {
   
   -- Brevvens's Tungsten
   ["tungsten-ore"] = {
-    ["result"] = "tungsten-ore",
+    ["results"] = { { type="item", name="tungsten-ore", amount=1 } },
     ["mining-liquid"] = "water",
     ["mining-liquid-amount"] = 100,
     ["patchimg"] = "ore",
@@ -705,7 +705,7 @@ local vtk_custom_ores = {
   
   -- Brevvens's Zirconium
   ["zircon"] = {
-    ["result"] = "zircon",
+    ["results"] = { { type="item", name="zircon", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore",
     ["frame"] = 4,
@@ -719,7 +719,7 @@ local vtk_custom_ores = {
   
   -- Space Exploration's ore support
   ["se-beryllium-ore"] = {
-    ["result"] = "se-beryllium-ore",
+    ["results"] = { { type="item", name="se-beryllium-ore", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore",
     ["frame"] = 4,
@@ -731,7 +731,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["se-cryonite"] = {
-    ["result"] = "se-cryonite",
+    ["results"] = { { type="item", name="se-cryonite", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore",
     ["frame"] = 4,
@@ -743,7 +743,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["se-holmium-ore"] = {
-    ["result"] = "se-holmium-ore",
+    ["results"] = { { type="item", name="se-holmium-ore", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore",
     ["frame"] = 4,
@@ -755,7 +755,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["se-iridium-ore"] = {
-    ["result"] = "se-iridium-ore",
+    ["results"] = { { type="item", name="se-iridium-ore", amount=1 } },
     ["mining-liquid"] = "sulfuric-acid", 
     ["mining-liquid-amount"] = 50, 
     ["img"] = "ore",
@@ -769,7 +769,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["se-naquium-ore"] = {
-    ["result"] = "se-naquium-ore",
+    ["results"] = { { type="item", name="se-naquium-ore", amount=1 } },
     ["mining-liquid"] = "sulfuric-acid", 
     ["mining-liquid-amount"] = 200, 
     ["img"] = "ore",
@@ -783,7 +783,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["se-vulcanite"] = {
-    ["result"] = "se-vulcanite",
+    ["results"] = { { type="item", name="se-vulcanite", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore",
     ["frame"] = 4,
@@ -795,7 +795,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["se-vitamelange"] = {
-    ["result"] = "se-vitamelange",
+    ["results"] = { { type="item", name="se-vitamelange", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore",
     ["frame"] = 4,
@@ -807,7 +807,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["se-water-ice"] = {
-    ["result"] = "se-water-ice",
+    ["results"] = { { type="item", name="se-water-ice", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore",
     ["frame"] = 4,
@@ -819,7 +819,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["se-methane-ice"] = {
-    ["result"] = "se-methane-ice",
+    ["results"] = { { type="item", name="se-methane-ice", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore",
     ["frame"] = 4,
@@ -833,7 +833,7 @@ local vtk_custom_ores = {
 
   --Industrial Revolution 2
   ["tin-ore"] = {
-    ["result"] = "tin-ore",
+    ["results"] = { { type="item", name="tin-ore", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore",
     ["frame"] = 4,
@@ -845,7 +845,7 @@ local vtk_custom_ores = {
     ["patchtint"] = true
   },
   ["gold-ore"] = {
-    ["result"] = "gold-ore",
+    ["results"] = { { type="item", name="gold-ore", amount=1 } },
     ["img"] = "ore",
     ["patchimg"] = "ore",
     ["frame"] = 4,
@@ -862,7 +862,7 @@ local vtk_custom_ores = {
 -- Process all existing resources to create deepcore mining reference for them to create associated patches, items, refining and technology
 for _, resource in pairs(data.raw.resource) do
   local proceed = false
-  local vtk_result = nil
+  local vtk_results = nil
   
   -- log(" new ore found : "..resource.name)
   -- log(serpent.block(resource))
@@ -879,18 +879,19 @@ for _, resource in pairs(data.raw.resource) do
     elseif resource.map_grid == false then
       proceed = false
     elseif resource.minable.result then
-        vtk_result = resource.minable.result
+        vtk_results = { { type="item", name=resource.minable.result, amount=1 } }
         proceed = true
     elseif resource.minable.results then
+      vtk_results = {}
       for _, result in ipairs(resource.minable.results) do
           -- log("loop _ "..serpent.block(_))
           -- log("loop result "..serpent.block(result))
           -- log("loop result.name "..serpent.block(result.name))
           if result.name and result.type ~= "fluid" then
-            vtk_result = result.name
+            table.insert(vtk_results, result)
             proceed = true
           elseif result[1] then
-            vtk_result = result[1]
+            table.insert(vtk_results, result)
             proceed = true
           end
       end
@@ -908,7 +909,7 @@ for _, resource in pairs(data.raw.resource) do
     else 
       local resources_to_support = {
         [resource.name] = {
-          ["result"] = vtk_result,
+          ["results"] = vtk_results,
           ["img"] = "ore", 
           ["patchimg"] = "ore", 
           ["frame"] = 4,


### PR DESCRIPTION
I'm playing with the bismuth and bzgold mod and notice that deep core mining is not handling ores with multiple results well (gold ore (gold + stone) and bismuthinite (bismuth and sulfur) in the mentioned case).

I looked at the code and modified it, so it now handles ores with multiple results.  If the results have some probability attached, then this is reflected in the MOHO miner and the refining recipe.

While doing this I also noticed that the list of supported ores has multiple entries for the same ore (because different mods provide the same ore with the same name).  I split the giant table into different section, where each section is only executed if the corresponding mod is installed.